### PR TITLE
chore: bump azcopy to v10.32.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt update \
   && apt update \
   && apt -y install azure-cli \
   && cd /usr/local/bin && curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && chmod a+x kubectl \
-  && curl --silent -L https://github.com/Azure/azure-storage-azcopy/releases/download/v10.32.0/azcopy-10.32.0.x86_64.deb -o /tmp/azcopy.dpkg && dpkg -i /tmp/azcopy.dpkg && rm /tmp/azcopy.dpkg \
+  && curl --silent -L https://github.com/Azure/azure-storage-azcopy/releases/download/v10.32.3/azcopy-10.32.3.x86_64.deb -o /tmp/azcopy.dpkg && dpkg -i /tmp/azcopy.dpkg && rm /tmp/azcopy.dpkg \
   && curl --silent -L https://github.com/mikefarah/yq/releases/download/v4.52.4/yq_linux_amd64 -o /usr/local/bin/yq \
   && chmod a+x /usr/local/bin/yq \
   && curl -kLso /tmp/oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-4.21/openshift-client-linux.tar.gz && tar -xzf /tmp/oc.tar.gz -C /usr/local/bin oc && rm /tmp/oc.tar.gz \


### PR DESCRIPTION
Bumps azcopy from v10.32.0 to v10.32.3 (latest GA).

Release notes: https://github.com/Azure/azure-storage-azcopy/releases/tag/v10.32.3